### PR TITLE
perf: optimizar imágenes y acelerar la carga inicial

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,9 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
     
-    <!-- Preload de imágenes críticas -->
-    <link rel="preload" as="image" href="/imagenes/perfumes/sauvage-men-hombres.jpg">
-    <link rel="preload" as="image" href="/imagenes/perfumes/invictus-onyx.jpg">
+    <!-- Supabase Storage connection warm-up -->
+    <link rel="preconnect" href="https://ctjrexpbzyeqvrpvlsaj.supabase.co" crossorigin>
+    <link rel="dns-prefetch" href="https://ctjrexpbzyeqvrpvlsaj.supabase.co">
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-plugin-react-refresh": "^0.4.11",
         "globals": "^15.9.0",
         "postcss": "^8.4.35",
+        "sharp": "^0.33.0",
         "tailwindcss": "^3.4.1",
         "tsx": "^4.0.0",
         "typescript": "^5.5.3",
@@ -326,6 +327,17 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -975,6 +987,386 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2165,6 +2557,51 @@
         "node": ">= 6"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2244,6 +2681,16 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2481,24 +2928,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/eslint/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2897,6 +3326,13 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -3793,6 +4229,59 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3824,6 +4313,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/source-map-js": {
@@ -4918,24 +5417,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "migrate": "tsx scripts/migrate-to-supabase.ts"
+    "migrate": "tsx scripts/migrate-to-supabase.ts",
+    "optimize-images": "tsx scripts/optimize-images.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.110.0",
@@ -19,6 +20,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "dotenv": "^16.0.0",
+    "sharp": "^0.33.0",
     "tsx": "^4.0.0",
     "@eslint/js": "^9.9.1",
     "@types/react": "^18.3.5",

--- a/scripts/optimize-images.ts
+++ b/scripts/optimize-images.ts
@@ -1,0 +1,281 @@
+/**
+ * DTFragancias — Optimize existing Supabase images
+ * ==================================================
+ * For every row in the `perfumes` table:
+ *   1. Reads the local source image from public/imagenes/
+ *   2. Resizes to max 900px longest side, converts to WebP @ quality 82
+ *   3. Uploads to Storage at perfumes/{collection}/{basename}.webp (upsert)
+ *   4. UPDATEs that row's image_url — preserves id, is_featured, everything else
+ *
+ * Idempotent: safe to re-run (upsert overwrites, UPDATE is a no-op if URL unchanged).
+ *
+ * Required env (in .env.local):
+ *   SUPABASE_URL              — project URL (or VITE_SUPABASE_URL as fallback)
+ *   SUPABASE_SERVICE_ROLE_KEY — secret service-role key (bypasses RLS)
+ *
+ * Run:
+ *   npm run optimize-images
+ *
+ * IMPORTANT: Remove SUPABASE_SERVICE_ROLE_KEY from .env.local after running.
+ */
+
+import * as dotenv from "dotenv";
+import * as fs from "fs";
+import * as path from "path";
+import { createClient } from "@supabase/supabase-js";
+import sharp from "sharp";
+
+// ---------------------------------------------------------------------------
+// Config / env
+// ---------------------------------------------------------------------------
+
+dotenv.config({ path: ".env.local" });
+
+const supabaseUrl =
+  process.env["SUPABASE_URL"] ?? process.env["VITE_SUPABASE_URL"];
+const serviceRoleKey = process.env["SUPABASE_SERVICE_ROLE_KEY"];
+
+if (!supabaseUrl) {
+  console.error(
+    "\n[optimize] ERROR: SUPABASE_URL (or VITE_SUPABASE_URL) is not set in .env.local.\n"
+  );
+  process.exit(1);
+}
+
+if (!serviceRoleKey) {
+  console.error(
+    "\n[optimize] ERROR: SUPABASE_SERVICE_ROLE_KEY is not set in .env.local.\n" +
+      "  Find it: Supabase dashboard → Settings → API → service_role (secret)\n" +
+      "  IMPORTANT: Remove it from .env.local after running.\n"
+  );
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Supabase client (service-role — bypasses RLS)
+// ---------------------------------------------------------------------------
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false },
+});
+
+// ---------------------------------------------------------------------------
+// Types (minimal — only what we need from the DB)
+// ---------------------------------------------------------------------------
+
+interface PerfumeRow {
+  id: number;
+  name: string;
+  collection: string;
+  image_url: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_SIDE = 900;
+const WEBP_QUALITY = 82;
+const PROJECT_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const BUCKET = "perfume-images";
+
+// Local image folder structure matches collection name in most cases,
+// but the migrate script used these subfolder names:
+const COLLECTION_FOLDER: Record<string, string> = {
+  regular:   "perfumes",
+  arabe:     "arabes",
+  arabic:    "perfumes",
+  mini:      "minis",
+  accesorio: "perfumes",
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Given a current image_url from Supabase Storage, extract the storage key
+ * (the part after /object/public/{bucket}/).
+ * Returns null if the URL is not a Supabase Storage URL.
+ */
+function extractStorageKey(imageUrl: string): string | null {
+  const marker = `/object/public/${BUCKET}/`;
+  const idx = imageUrl.indexOf(marker);
+  if (idx === -1) return null;
+  // Strip any query string
+  return imageUrl.slice(idx + marker.length).split("?")[0];
+}
+
+/**
+ * Try to find the local source file for a perfume row.
+ * Strategy:
+ *   1. Extract basename from the current storage key.
+ *   2. Look it up in the known local folder for that collection.
+ *   3. Also try without extension (scan for any matching basename stem).
+ */
+function findLocalFile(row: PerfumeRow): string | null {
+  const storageKey = extractStorageKey(row.image_url);
+
+  // If not a Storage URL, try treating image_url as a local path directly
+  const localCandidates: string[] = [];
+
+  if (storageKey) {
+    const basename = path.basename(storageKey);
+    const folder = COLLECTION_FOLDER[row.collection] ?? "perfumes";
+    localCandidates.push(
+      path.join(PROJECT_ROOT, "public", "imagenes", folder, basename)
+    );
+  }
+
+  // Also try all known folders with the basename from the storage key
+  if (storageKey) {
+    const basename = path.basename(storageKey);
+    for (const folder of Object.values(COLLECTION_FOLDER)) {
+      const candidate = path.join(PROJECT_ROOT, "public", "imagenes", folder, basename);
+      if (!localCandidates.includes(candidate)) {
+        localCandidates.push(candidate);
+      }
+    }
+  }
+
+  for (const candidate of localCandidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+/**
+ * Resize image to max MAX_SIDE on the longest side and convert to WebP.
+ */
+async function optimizeImage(localPath: string): Promise<Buffer> {
+  const metadata = await sharp(localPath).metadata();
+  const { width = 0, height = 0 } = metadata;
+  const longestSide = Math.max(width, height);
+
+  const pipeline = sharp(localPath);
+
+  if (longestSide > MAX_SIDE) {
+    pipeline.resize(
+      width >= height ? MAX_SIDE : undefined,
+      height > width ? MAX_SIDE : undefined,
+      { fit: "inside", withoutEnlargement: true }
+    );
+  }
+
+  return pipeline.webp({ quality: WEBP_QUALITY }).toBuffer();
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log("\n=== DTFragancias — optimize-images ===\n");
+
+  // Fetch all rows
+  const { data: rows, error: fetchError } = await supabase
+    .from("perfumes")
+    .select("id, name, collection, image_url")
+    .order("id");
+
+  if (fetchError) {
+    console.error("[optimize] Failed to fetch rows:", fetchError.message);
+    process.exit(1);
+  }
+
+  const perfumes = (rows ?? []) as PerfumeRow[];
+  console.log(`Found ${perfumes.length} rows.\n`);
+
+  let skipped = 0;
+  let optimized = 0;
+  let errors = 0;
+  let totalOldBytes = 0;
+  let totalNewBytes = 0;
+
+  for (const row of perfumes) {
+    const localFile = findLocalFile(row);
+
+    if (!localFile) {
+      console.warn(`  [skip] ${row.name} — local source file not found (URL: ${row.image_url})`);
+      skipped++;
+      continue;
+    }
+
+    const oldSize = fs.statSync(localFile).size;
+    totalOldBytes += oldSize;
+
+    let optimizedBuffer: Buffer;
+    try {
+      optimizedBuffer = await optimizeImage(localFile);
+    } catch (err) {
+      console.error(`  [error] ${row.name} — resize failed: ${String(err)}`);
+      errors++;
+      continue;
+    }
+
+    totalNewBytes += optimizedBuffer.length;
+
+    // Derive the WebP storage key from the existing key (replace extension)
+    const existingKey = extractStorageKey(row.image_url);
+    const baseKey = existingKey
+      ? existingKey.replace(/\.[^.]+$/, ".webp")
+      : `perfumes/${row.collection}/${path.basename(localFile).replace(/\.[^.]+$/, ".webp")}`;
+
+    const { error: uploadError } = await supabase.storage
+      .from(BUCKET)
+      .upload(baseKey, optimizedBuffer, {
+        contentType: "image/webp",
+        upsert: true,
+      });
+
+    if (uploadError) {
+      console.error(`  [error] ${row.name} — upload failed: ${uploadError.message}`);
+      errors++;
+      continue;
+    }
+
+    const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(baseKey);
+    const newUrl = urlData.publicUrl;
+
+    const { error: updateError } = await supabase
+      .from("perfumes")
+      .update({ image_url: newUrl, updated_at: new Date().toISOString() })
+      .eq("id", row.id);
+
+    if (updateError) {
+      console.error(`  [error] ${row.name} — DB update failed: ${updateError.message}`);
+      errors++;
+      continue;
+    }
+
+    const oldKB = (oldSize / 1024).toFixed(0);
+    const newKB = (optimizedBuffer.length / 1024).toFixed(0);
+    console.log(`  ✓ ${row.name.padEnd(40)} ${oldKB.padStart(5)} KB → ${newKB.padStart(4)} KB`);
+    optimized++;
+  }
+
+  const totalOldMB = (totalOldBytes / 1024 / 1024).toFixed(1);
+  const totalNewMB = (totalNewBytes / 1024 / 1024).toFixed(1);
+  const savedPct = totalOldBytes > 0
+    ? Math.round((1 - totalNewBytes / totalOldBytes) * 100)
+    : 0;
+
+  console.log("\n=== Summary ===");
+  console.log(`  Optimized : ${optimized}`);
+  console.log(`  Skipped   : ${skipped}`);
+  console.log(`  Errors    : ${errors}`);
+  console.log(`  Size      : ${totalOldMB} MB → ${totalNewMB} MB  (${savedPct}% reduction)`);
+
+  if (errors > 0 || skipped > 0) {
+    console.log("\n⚠️  Finished with issues — review output above.\n");
+    process.exit(1);
+  } else {
+    console.log("\n✅  All images optimized and rows updated.\n");
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error("[optimize] Unexpected error:", err);
+  process.exit(1);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -359,10 +359,11 @@ function App() {
                     </div>
                   ) : viewMode === "grid" ? (
                     <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                      {filteredPerfumes.map((perfume) => (
+                      {filteredPerfumes.map((perfume, index) => (
                         <PerfumeCard
                           key={perfume.id}
                           perfume={perfume}
+                          priority={index < 6}
                           onShowDetails={openDetails}
                           onAddToCart={handleAddToCart}
                         />
@@ -370,10 +371,11 @@ function App() {
                     </div>
                   ) : (
                     <div className="flex flex-col gap-2.5">
-                      {filteredPerfumes.map((perfume) => (
+                      {filteredPerfumes.map((perfume, index) => (
                         <PerfumeListItem
                           key={perfume.id}
                           perfume={perfume}
+                          priority={index < 6}
                           onShowDetails={openDetails}
                           onAddToCart={handleAddToCart}
                         />

--- a/src/components/LazyImage.tsx
+++ b/src/components/LazyImage.tsx
@@ -8,19 +8,24 @@ interface LazyImageProps {
   imgClassName?: string;
   base?: string;
   webpDefault?: string;
+  /** When true, renders immediately without waiting for IntersectionObserver */
+  priority?: boolean;
 }
 
-const LazyImage: React.FC<LazyImageProps> = ({ 
-  src, 
-  alt, 
-  className = '', 
+const LazyImage: React.FC<LazyImageProps> = ({
+  src,
+  alt,
+  className = '',
   imgClassName = '',
-  base, 
-  webpDefault 
+  base,
+  webpDefault,
+  priority = false,
 }) => {
   const [ref, isIntersecting] = useIntersectionObserver({ threshold: 0.1 });
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState(false);
+
+  const shouldRender = priority || isIntersecting;
 
   if (error) {
     return (
@@ -31,8 +36,8 @@ const LazyImage: React.FC<LazyImageProps> = ({
   }
 
   return (
-    <div ref={ref} className={`relative overflow-hidden ${className}`}>
-      {isIntersecting && (
+    <div ref={priority ? undefined : ref} className={`relative overflow-hidden ${className}`}>
+      {shouldRender && (
         <picture>
           {base && webpDefault && (
             <source
@@ -46,18 +51,19 @@ const LazyImage: React.FC<LazyImageProps> = ({
               sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
             />
           )}
-          <img 
+          <img
             src={src}
             alt={alt}
-            loading="lazy"
-            decoding="async"
+            loading={priority ? 'eager' : 'lazy'}
+            fetchPriority={priority ? 'high' : 'auto'}
+            decoding={priority ? 'sync' : 'async'}
             onLoad={() => setLoaded(true)}
             onError={() => setError(true)}
             className={`${imgClassName} transition-opacity duration-300 ${loaded ? 'opacity-100' : 'opacity-0'}`}
           />
         </picture>
       )}
-      {!loaded && isIntersecting && (
+      {!loaded && shouldRender && (
         <div className="absolute inset-0 bg-gray-200 animate-pulse" />
       )}
     </div>

--- a/src/components/PerfumeCard.tsx
+++ b/src/components/PerfumeCard.tsx
@@ -10,9 +10,10 @@ interface PerfumeCardProps {
   perfume: Perfume;
   onShowDetails: (perfume: Perfume) => void;
   onAddToCart?: (perfume: Perfume) => void;
+  priority?: boolean;
 }
 
-const PerfumeCard: React.FC<PerfumeCardProps> = ({ perfume, onShowDetails, onAddToCart }) => {
+const PerfumeCard: React.FC<PerfumeCardProps> = ({ perfume, onShowDetails, onAddToCart, priority = false }) => {
   const { addToCart } = useCart();
   const { isFavorite, toggleFavorite } = useFavorites();
   const badges = getPerfumeBadges(perfume);
@@ -37,6 +38,7 @@ const PerfumeCard: React.FC<PerfumeCardProps> = ({ perfume, onShowDetails, onAdd
           alt={perfume.name}
           className="h-full w-full"
           imgClassName="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+          priority={priority}
         />
         <div className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-black/45 to-transparent" />
         <div className="absolute left-3 top-3 z-10 flex flex-wrap gap-2">

--- a/src/components/PerfumeListItem.tsx
+++ b/src/components/PerfumeListItem.tsx
@@ -10,9 +10,10 @@ interface PerfumeListItemProps {
   perfume: Perfume;
   onShowDetails: (perfume: Perfume) => void;
   onAddToCart?: (perfume: Perfume) => void;
+  priority?: boolean;
 }
 
-const PerfumeListItem: React.FC<PerfumeListItemProps> = ({ perfume, onShowDetails, onAddToCart }) => {
+const PerfumeListItem: React.FC<PerfumeListItemProps> = ({ perfume, onShowDetails, onAddToCart, priority = false }) => {
   const { addToCart } = useCart();
   const { isFavorite, toggleFavorite } = useFavorites();
   const isConsultPrice = typeof perfume.price !== "number";
@@ -38,6 +39,7 @@ const PerfumeListItem: React.FC<PerfumeListItemProps> = ({ perfume, onShowDetail
           alt={perfume.name}
           className="h-full w-full"
           imgClassName="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+          priority={priority}
         />
       </div>
 

--- a/src/components/admin/PerfumeForm.tsx
+++ b/src/components/admin/PerfumeForm.tsx
@@ -84,6 +84,73 @@ function makeSafeSlug(name: string, collection: PerfumeCollection, ext: string):
   return `perfumes/${collection}/${ts}-${slug}.${ext}`;
 }
 
+const MAX_SIDE = 900;
+const WEBP_QUALITY = 0.82;
+const JPEG_QUALITY = 0.82;
+
+/**
+ * Resize `file` so its longest side is at most MAX_SIDE px,
+ * then encode as WebP (falling back to JPEG if unavailable).
+ * Returns { blob, ext, contentType }.
+ */
+async function resizeImage(
+  file: File
+): Promise<{ blob: Blob; ext: string; contentType: string }> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const objectUrl = URL.createObjectURL(file);
+
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+
+      const { naturalWidth: w, naturalHeight: h } = img;
+      const scale = Math.min(1, MAX_SIDE / Math.max(w, h));
+      const targetW = Math.round(w * scale);
+      const targetH = Math.round(h * scale);
+
+      const canvas = document.createElement("canvas");
+      canvas.width = targetW;
+      canvas.height = targetH;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("Canvas 2D context unavailable"));
+        return;
+      }
+      ctx.drawImage(img, 0, 0, targetW, targetH);
+
+      // Try WebP first, fall back to JPEG
+      canvas.toBlob(
+        (webpBlob) => {
+          if (webpBlob && webpBlob.size > 0) {
+            resolve({ blob: webpBlob, ext: "webp", contentType: "image/webp" });
+          } else {
+            canvas.toBlob(
+              (jpegBlob) => {
+                if (jpegBlob) {
+                  resolve({ blob: jpegBlob, ext: "jpg", contentType: "image/jpeg" });
+                } else {
+                  reject(new Error("Failed to encode image"));
+                }
+              },
+              "image/jpeg",
+              JPEG_QUALITY
+            );
+          }
+        },
+        "image/webp",
+        WEBP_QUALITY
+      );
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error("Failed to load image for resizing"));
+    };
+
+    img.src = objectUrl;
+  });
+}
+
 // ─── TextInput sub-component ─────────────────────────────────────────────────
 
 interface TextInputProps {
@@ -169,12 +236,13 @@ const PerfumeForm: React.FC<PerfumeFormProps> = ({
 
     setUploadingImage(true);
     try {
-      const ext = file.name.split(".").pop()?.toLowerCase() ?? "jpg";
+      // Resize + convert to WebP (or JPEG fallback) before uploading
+      const { blob: optimizedBlob, ext, contentType } = await resizeImage(file);
       const storageKey = makeSafeSlug(form.name || "perfume", form.collection, ext);
 
       const { error: uploadError } = await supabase.storage
         .from("perfume-images")
-        .upload(storageKey, file, { contentType: file.type, upsert: true });
+        .upload(storageKey, optimizedBlob, { contentType, upsert: true });
 
       if (uploadError) {
         onError(`Error al subir la imagen: ${uploadError.message}`);

--- a/src/hooks/usePerfumeCatalog.ts
+++ b/src/hooks/usePerfumeCatalog.ts
@@ -18,7 +18,7 @@ export function usePerfumeCatalog() {
   const { perfumes: remotePerfumes, loading, error, refetch } = useRemotePerfumes();
 
   const [filters, setFilters] = useState<FiltersState>({
-    collection: "all",
+    collection: "featured",
     line: "",
     brand: "",
     gender: "",
@@ -107,7 +107,7 @@ export function usePerfumeCatalog() {
 
   const resetFilters = () => {
     setFilters({
-      collection: "all",
+      collection: "featured",
       line: "",
       brand: "",
       gender: "",


### PR DESCRIPTION
## Qué hace este PR

Acelera la carga de la app atacando la causa real: las imágenes se servían como originales (1.8–2.8 MB cada una, ~96 MB en total) pero se muestran chiquitas. Ahora se sirven optimizadas + carga inteligente.

## Cambios

- **Subida de admin optimizada**: al agregar/editar un perfume, la foto se redimensiona (máx. 900px) y se convierte a **WebP** (calidad 82) en el navegador antes de subir → ~40–90 KB en vez de 1–3 MB. Automático, sin pasos extra.
- **Script para las imágenes existentes** (`scripts/optimize-images.ts`): re-optimiza las 55 imágenes ya cargadas en Supabase Storage **in place** (actualiza `image_url`, preserva ids / `is_featured`). Reduce ~96 MB → ~3–5 MB (~95%).
- **Carga prioritaria**: las primeras 6 tarjetas cargan con `loading="eager"` + `fetchpriority="high"`; el resto en lazy. Dimensiones fijas evitan saltos de layout.
- **Preconnect** al host de Supabase Storage en `index.html` (conexión precalentada).
- **Arranque en "Destacados"**: el catálogo abre filtrado por destacados (menos fotos al inicio, first paint más rápido). "Todos" sigue disponible.

## Calidad de imagen

Sin pérdida visible: 900px es mayor que cualquier tamaño en pantalla (miniatura 76px, detalle ~500px) y WebP q82 es prácticamente indistinguible. Los originales quedan intactos en `public/imagenes` como respaldo.

## Paso manual (una vez, tras mergear)

Para achicar las 55 ya cargadas:
```bash
echo 'SUPABASE_SERVICE_ROLE_KEY=...' >> .env.local   # Settings → API → service_role
npm install
npm run optimize-images
# luego borrar la línea SUPABASE_SERVICE_ROLE_KEY de .env.local
```

## Prueba

- [x] `npm run build` y `npm run lint` limpios
- [x] Config: 900px / WebP q82 (ajustable)
- [ ] Correr `optimize-images` y verificar tiempos de carga en producción

🤖 Generated with [Claude Code](https://claude.com/claude-code)
