### PR TITLE
fix(admin): no recargar la lista entera al destacar

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -44,6 +44,8 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
   // Error banner (for CRUD errors surfaced by child forms)
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [savingFeaturedIds, setSavingFeaturedIds] = useState<number[]>([]);
+  /** Set by edits that only need to reach the public catalog once, on close. */
+  const [catalogNeedsRefresh, setCatalogNeedsRefresh] = useState(false);
 
   // Toast
   const [toastMessage, setToastMessage] = useState("");
@@ -52,7 +54,16 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
   const isAuthenticated = session !== null;
 
   // Remote data — only fetch when panel is open and user is authenticated
-  const { perfumes, loading: perfumesLoading, refetch } = useRemotePerfumes();
+  const { perfumes, loading: perfumesLoading, refetch, patchPerfume } = useRemotePerfumes();
+
+  /** Propagates pending changes to the public catalog exactly once, on close. */
+  const handleClose = () => {
+    if (catalogNeedsRefresh) {
+      setCatalogNeedsRefresh(false);
+      onSaved();
+    }
+    onClose();
+  };
 
   if (!isOpen) return null;
 
@@ -112,19 +123,25 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
     setErrorMessage(null);
     setSavingFeaturedIds(ids => [...ids, perfume.id]);
 
+    // The star flips right away and stays flipped: re-reading all 428 rows to
+    // learn about the one we just wrote made the list blink out to a spinner
+    // on every click.
+    patchPerfume(perfume.id, { isFeatured: next });
+
     const result = await setPerfumeFeatured(perfume.id, next);
+    setSavingFeaturedIds(ids => ids.filter(id => id !== perfume.id));
 
     if (!result.ok) {
+      patchPerfume(perfume.id, { isFeatured: perfume.isFeatured });
       setErrorMessage(result.error);
-      setSavingFeaturedIds(ids => ids.filter(id => id !== perfume.id));
       return;
     }
 
     setToastMessage(`"${perfume.name}" ${next ? "destacado" : "quitado de destacados"}.`);
     setShowToast(true);
-    await refetch();
-    setSavingFeaturedIds(ids => ids.filter(id => id !== perfume.id));
-    onSaved();
+    // The public catalog is refreshed once, when the panel closes, rather than
+    // on every star.
+    setCatalogNeedsRefresh(true);
   };
 
   // ── Form callbacks ────────────────────────────────────────────────────────────
@@ -174,7 +191,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
           <div className="flex items-center gap-2">
             {isAuthenticated && onOpenCarousel && (
               <button
-                onClick={() => { onClose(); onOpenCarousel(); }}
+                onClick={() => { handleClose(); onOpenCarousel(); }}
                 className="flex items-center gap-1.5 rounded-md border border-[#E8DDBF] px-3 py-2 text-sm font-medium text-[#1A2238] transition-colors hover:border-[#D4AF37] hover:text-[#D4AF37]"
                 title="Generador de carruseles para Instagram"
               >
@@ -184,7 +201,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
             )}
             {isAuthenticated && onOpenContentStudio && (
               <button
-                onClick={() => { onClose(); onOpenContentStudio(); }}
+                onClick={() => { handleClose(); onOpenContentStudio(); }}
                 className="flex items-center gap-1.5 rounded-md border border-[#E8DDBF] px-3 py-2 text-sm font-medium text-[#1A2238] transition-colors hover:border-[#D4AF37] hover:text-[#D4AF37]"
                 title="Ir al Content Studio"
               >
@@ -203,7 +220,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
               </button>
             )}
             <button
-              onClick={onClose}
+              onClick={handleClose}
               className="rounded-md p-2 text-gray-500 hover:bg-gray-100"
               aria-label="Cerrar admin"
             >

--- a/src/hooks/useRemotePerfumes.ts
+++ b/src/hooks/useRemotePerfumes.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { USE_LOCAL_CATALOG } from "../lib/supabase";
 import { fetchPerfumes as fetchFromRepository } from "../data/perfumesRepository";
 import { Perfume } from "../types";
@@ -8,6 +8,13 @@ export interface UseRemotePerfumesResult {
   loading: boolean;
   error: string | null;
   refetch: () => Promise<void>;
+  /**
+   * Applies a change to one product in memory, without going back to the
+   * network. For writes that already succeeded: the database is the authority
+   * on what was saved, so re-reading the whole catalog to learn about a single
+   * row we just wrote is a round trip nobody needs.
+   */
+  patchPerfume: (id: number, changes: Partial<Perfume>) => void;
 }
 
 export function useRemotePerfumes(): UseRemotePerfumesResult {
@@ -15,8 +22,12 @@ export function useRemotePerfumes(): UseRemotePerfumesResult {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Only the very first load has nothing to show. A refresh keeps the current
+  // list on screen instead of swapping it for a spinner.
+  const hasLoadedOnce = useRef(false);
+
   const load = useCallback(async () => {
-    setLoading(true);
+    if (!hasLoadedOnce.current) setLoading(true);
     setError(null);
 
     // Preview what src/data holds before pushing it live with `npm run sync-catalog`.
@@ -25,6 +36,7 @@ export function useRemotePerfumes(): UseRemotePerfumesResult {
     if (USE_LOCAL_CATALOG) {
       const { perfumes: localPerfumes } = await import("../data");
       setPerfumes(localPerfumes);
+      hasLoadedOnce.current = true;
       setLoading(false);
       return;
     }
@@ -33,12 +45,19 @@ export function useRemotePerfumes(): UseRemotePerfumesResult {
     if (result.ok) setPerfumes(result.data);
     else setError(result.error);
 
+    hasLoadedOnce.current = true;
     setLoading(false);
+  }, []);
+
+  const patchPerfume = useCallback((id: number, changes: Partial<Perfume>) => {
+    setPerfumes(current =>
+      current.map(perfume => (perfume.id === id ? { ...perfume, ...changes } : perfume))
+    );
   }, []);
 
   useEffect(() => {
     void load();
   }, [load]);
 
-  return { perfumes, loading, error, refetch: load };
+  return { perfumes, loading, error, refetch: load, patchPerfume };
 }


### PR DESCRIPTION
Tocar una estrella dejó de recargar la lista entera.

## Qué pasaba

Un solo clic en la estrella disparaba **dos descargas completas de 428 filas**:

```
handleToggleFeatured
  ├─ await refetch()   → 428 filas para la lista del admin
  └─ onSaved()         → refetchCatalog() → otras 428 para el catálogo público
```

Y como `refetch()` volvía a poner `loading = true`, esto se activaba:

```tsx
// PerfumeList.tsx
if (loading) return <spinner "Cargando perfumes…" />
```

La lista completa desaparecía y se reemplazaba por el spinner. Cada clic tiraba a la basura lo que estabas mirando para volver a averiguar algo que la escritura ya había confirmado.

## Qué cambia

- **La estrella se actualiza en el lugar.** `patchPerfume` modifica ese producto en memoria; si la escritura falla, vuelve atrás y muestra el error. La lista no se mueve.
- **`loading` sólo se activa en la primera carga.** Un refresh mantiene la lista en pantalla en vez de cambiarla por un spinner — esto también arregla el mismo parpadeo después de borrar.
- **El catálogo público se refresca una sola vez, al cerrar el panel**, en lugar de después de cada edición.

## Verificación

- `tsc --noEmit` y `eslint` sin errores
- Catálogo público sin cambios: 428 productos, 24 cards, sin errores de carga
- **La estrella no la pude probar con sesión real** — el panel está detrás del login y en headless no tengo credenciales. Conviene tocarla antes de mergear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
