### PR TITLE
feat(catalog): filtros en barra horizontal, 4 columnas de productos

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -210,8 +210,8 @@ function App() {
                   </h2>
                 </div>
                 <p className="max-w-xl text-sm leading-6 text-gray-600">
-                  Usá filtros para encontrar una fragancia por marca, perfil, género o
-                  presupuesto.
+                  Usá los filtros para encontrar una fragancia por línea, género o
+                  presupuesto, o buscá por nombre desde arriba.
                 </p>
               </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,6 +99,17 @@ function App() {
     localStorage.setItem(FILTERS_LAYOUT_STORAGE_KEY, filtersLayout);
   }, [filtersLayout]);
 
+  /**
+   * El logo devuelve el catálogo a como estaba al entrar: sin filtros, sin
+   * búsqueda, sin modal abierto y arriba de todo. Es la salida que la gente
+   * busca instintivamente cuando se perdió entre filtros.
+   */
+  const goHome = () => {
+    resetFilters();
+    closeDetails();
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
   const handleAddToCart = (perfume: Perfume) => {
     setToastMessage(`${perfume.name} agregado al carrito`);
     setShowToast(true);
@@ -158,6 +169,7 @@ function App() {
             onSearch={handleSearch}
             toggleCart={toggleCart}
             onOpenAdmin={openAdmin}
+            onGoHome={goHome}
           />
 
           <main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, lazy, Suspense } from "react";
 import { CartProvider } from "./context/CartContext";
 import { FavoritesProvider } from "./context/FavoritesContext";
 import Header from "./components/Header";
-import Filters from "./components/Filters";
+import Filters, { FiltersLayout } from "./components/Filters";
 import PerfumeCard from "./components/PerfumeCard";
 import PerfumeListItem from "./components/PerfumeListItem";
 import PerfumeDetails from "./components/PerfumeDetails";
@@ -36,6 +36,7 @@ function ToolLoading() {
 
 type ViewMode = "grid" | "list";
 const VIEW_MODE_STORAGE_KEY = "dtfragancias_view_mode";
+const FILTERS_LAYOUT_STORAGE_KEY = "dtfragancias_filters_layout";
 
 function App() {
   const { session } = useAdminAuth();
@@ -75,6 +76,12 @@ function App() {
 
   const [toastMessage, setToastMessage] = useState("");
   const [showToast, setShowToast] = useState(false);
+  // Filters across the top by default: the side panel costs a quarter of the
+  // width, which on a large screen is a whole column of products.
+  const [filtersLayout, setFiltersLayout] = useState<FiltersLayout>(() => {
+    const saved = localStorage.getItem(FILTERS_LAYOUT_STORAGE_KEY);
+    return saved === "panel" || saved === "bar" ? saved : "bar";
+  });
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const saved = localStorage.getItem(VIEW_MODE_STORAGE_KEY);
     if (saved === "grid" || saved === "list") return saved;
@@ -83,10 +90,14 @@ function App() {
     return "grid";
   });
 
-  // Persiste preferencia de vista
+  // Persiste preferencias de vista
   useEffect(() => {
     localStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode);
   }, [viewMode]);
+
+  useEffect(() => {
+    localStorage.setItem(FILTERS_LAYOUT_STORAGE_KEY, filtersLayout);
+  }, [filtersLayout]);
 
   const handleAddToCart = (perfume: Perfume) => {
     setToastMessage(`${perfume.name} agregado al carrito`);
@@ -249,22 +260,52 @@ function App() {
               )}
 
               {!catalogLoading && !catalogError && (
-              <div className="flex flex-col gap-8 lg:flex-row">
-                <div className="lg:w-1/4">
+              <div className={filtersLayout === "bar" ? "flex flex-col gap-4" : "flex flex-col gap-8 lg:flex-row"}>
+                <div className={filtersLayout === "bar" ? "" : "lg:w-1/4"}>
                   <Filters
                     filters={filters}
                     onFilterChange={handleFilterChange}
                     onResetFilters={resetFilters}
                     perfumes={allPerfumes}
+                    layout={filtersLayout}
                   />
                 </div>
 
-                <div className="lg:w-3/4">
+                <div className={filtersLayout === "bar" ? "" : "lg:w-3/4"}>
                   <div className="mb-4 flex flex-col gap-3 rounded-lg border border-white/70 bg-white/80 p-3 shadow-sm backdrop-blur sm:flex-row sm:items-center sm:justify-between">
                     <div className="text-sm text-gray-600">
                       Mostrando{" "}
                       <strong className="text-[#1A2238]">{visiblePerfumes.length}</strong>{" "}
                       de {filteredPerfumes.length} perfumes
+                    </div>
+                    <div className="flex items-center gap-2">
+                    {/* Filtros arriba libera el cuarto de ancho del panel: la
+                        grilla pasa de 3 a 4 columnas en pantallas grandes. */}
+                    <div className="hidden w-fit gap-1 rounded-lg bg-[#EEF0F4] p-1 lg:flex">
+                      <button
+                        onClick={() => setFiltersLayout("bar")}
+                        className={`rounded px-3 py-1.5 text-xs font-medium transition-colors duration-200 ${
+                          filtersLayout === "bar"
+                            ? "bg-[#1A2238] text-white"
+                            : "text-gray-600 hover:bg-gray-100"
+                        }`}
+                        aria-pressed={filtersLayout === "bar"}
+                        title="Filtros en barra — más ancho para la grilla"
+                      >
+                        Barra
+                      </button>
+                      <button
+                        onClick={() => setFiltersLayout("panel")}
+                        className={`rounded px-3 py-1.5 text-xs font-medium transition-colors duration-200 ${
+                          filtersLayout === "panel"
+                            ? "bg-[#1A2238] text-white"
+                            : "text-gray-600 hover:bg-gray-100"
+                        }`}
+                        aria-pressed={filtersLayout === "panel"}
+                        title="Filtros en panel lateral"
+                      >
+                        Panel
+                      </button>
                     </div>
                     <div className="flex w-fit gap-1 rounded-lg bg-[#EEF0F4] p-1">
                       <button
@@ -292,6 +333,7 @@ function App() {
                         <List size={20} />
                       </button>
                     </div>
+                    </div>
                   </div>
 
                   {filteredPerfumes.length === 0 ? (
@@ -310,7 +352,11 @@ function App() {
                   ) : (
                     <>
                       {viewMode === "grid" ? (
-                        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                        <div
+                          className={`grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 ${
+                            filtersLayout === "bar" ? "xl:grid-cols-4" : ""
+                          }`}
+                        >
                           {visiblePerfumes.map((perfume, index) => (
                             <PerfumeCard
                               key={perfume.id}

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -13,9 +13,7 @@ export type FiltersLayout = "panel" | "bar";
 interface FiltersState {
   collection: string;
   line: string;
-  brand: string;
   gender: string;
-  category: string;
   minPrice: string;
   maxPrice: string;
   sort: string;
@@ -42,8 +40,6 @@ const Filters: React.FC<FilterProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const brands = Array.from(new Set(perfumes.map(perfume => perfume.brand))).sort((a, b) => a.localeCompare(b, "es"));
-  const categories = Array.from(new Set(perfumes.map(perfume => perfume.category))).sort((a, b) => a.localeCompare(b, "es"));
   const genders = Array.from(new Set(perfumes.map(perfume => perfume.gender)));
   const presentLines = new Set(perfumes.map(perfume => perfume.collection));
   const lineCollections = LINE_ORDER.filter(collection => presentLines.has(collection));
@@ -55,9 +51,7 @@ const Filters: React.FC<FilterProps> = ({
   const lineLabel = filters.line ? COLLECTION_LABELS[filters.line as PerfumeCollection] : "";
   const activeFilters = [
     lineLabel,
-    filters.brand,
     filters.gender,
-    filters.category,
     filters.minPrice && `Desde ${formatPrice(Number(filters.minPrice))}`,
     filters.maxPrice && `Hasta ${formatPrice(Number(filters.maxPrice))}`,
   ].filter(Boolean);
@@ -79,19 +73,6 @@ const Filters: React.FC<FilterProps> = ({
     </select>
   );
 
-  const brandSelect = (
-    <select
-      id="brand-filter"
-      aria-label="Marca"
-      value={filters.brand}
-      onChange={(e) => onFilterChange('brand', e.target.value)}
-      className={SELECT_CLASS}
-    >
-      <option value="">Todas las marcas</option>
-      {brands.map((brand) => <option key={brand} value={brand}>{brand}</option>)}
-    </select>
-  );
-
   const genderSelect = (
     <select
       id="gender-filter"
@@ -103,21 +84,6 @@ const Filters: React.FC<FilterProps> = ({
       <option value="">Todos los géneros</option>
       {genders.map((gender) => (
         <option key={gender} value={gender}>{gender.charAt(0).toUpperCase() + gender.slice(1)}</option>
-      ))}
-    </select>
-  );
-
-  const categorySelect = (
-    <select
-      id="category-filter"
-      aria-label="Categoría"
-      value={filters.category}
-      onChange={(e) => onFilterChange('category', e.target.value)}
-      className={SELECT_CLASS}
-    >
-      <option value="">Todas las categorías</option>
-      {categories.map((category) => (
-        <option key={category} value={category}>{category.charAt(0).toUpperCase() + category.slice(1)}</option>
       ))}
     </select>
   );
@@ -208,13 +174,11 @@ const Filters: React.FC<FilterProps> = ({
         </button>
 
         <div className={`${isOpen ? 'mt-3 block' : 'hidden'} lg:mt-0 lg:block`}>
-          {/* Seven columns so the price range — two inputs sharing a cell —
-              gets double the width of a single select and stops clipping. */}
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-7 lg:items-center">
+          {/* Five columns so the price range — two inputs sharing a cell — gets
+              double the width of a single select and stops clipping. */}
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-5 lg:items-center">
             {lineSelect}
-            {brandSelect}
             {genderSelect}
-            {categorySelect}
             {sortSelect}
             <div className="sm:col-span-2 lg:col-span-2">{priceInputs}</div>
           </div>
@@ -267,18 +231,8 @@ const Filters: React.FC<FilterProps> = ({
         </div>
 
         <div className="mb-4">
-          <label htmlFor="brand-filter" className="mb-2 block font-medium text-[#1A2238]">Marca</label>
-          {brandSelect}
-        </div>
-
-        <div className="mb-4">
           <label htmlFor="gender-filter" className="mb-2 block font-medium text-[#1A2238]">Género</label>
           {genderSelect}
-        </div>
-
-        <div className="mb-4">
-          <label htmlFor="category-filter" className="mb-2 block font-medium text-[#1A2238]">Categoría</label>
-          {categorySelect}
         </div>
 
         <div className="mb-4">

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -8,24 +8,40 @@ const LINE_ORDER: PerfumeCollection[] = [
   "regular", "arabe", "arabic", "jacques", "mini", "probador", "home", "accesorio",
 ];
 
-interface FilterProps {
-  filters: {
-    collection: string;
-    line: string;
-    brand: string;
-    gender: string;
-    category: string;
-    minPrice: string;
-    maxPrice: string;
-    sort: string;
-  };
-  onFilterChange: (name: keyof FilterProps['filters'], value: string) => void;
-  onResetFilters: () => void;
-  perfumes: Perfume[];
+export type FiltersLayout = "panel" | "bar";
+
+interface FiltersState {
+  collection: string;
+  line: string;
+  brand: string;
+  gender: string;
+  category: string;
+  minPrice: string;
+  maxPrice: string;
+  sort: string;
 }
 
-const Filters: React.FC<FilterProps> = ({ filters, onFilterChange, onResetFilters, perfumes }) => {
+interface FilterProps {
+  filters: FiltersState;
+  onFilterChange: (name: keyof FiltersState, value: string) => void;
+  onResetFilters: () => void;
+  perfumes: Perfume[];
+  /** "bar" lays the controls across the top so the grid gets the full width. */
+  layout?: FiltersLayout;
+}
+
+const SELECT_CLASS =
+  "w-full rounded border border-gray-300 bg-white p-2 focus:outline-none focus:ring-1 focus:ring-[#D4AF37]";
+
+const Filters: React.FC<FilterProps> = ({
+  filters,
+  onFilterChange,
+  onResetFilters,
+  perfumes,
+  layout = "panel",
+}) => {
   const [isOpen, setIsOpen] = useState(false);
+
   const brands = Array.from(new Set(perfumes.map(perfume => perfume.brand))).sort((a, b) => a.localeCompare(b, "es"));
   const categories = Array.from(new Set(perfumes.map(perfume => perfume.category))).sort((a, b) => a.localeCompare(b, "es"));
   const genders = Array.from(new Set(perfumes.map(perfume => perfume.gender)));
@@ -46,11 +62,187 @@ const Filters: React.FC<FilterProps> = ({ filters, onFilterChange, onResetFilter
     filters.maxPrice && `Hasta ${formatPrice(Number(filters.maxPrice))}`,
   ].filter(Boolean);
 
+  // Both layouts drive the same state, so the controls are declared once and
+  // only their wrapper changes.
+  const lineSelect = (
+    <select
+      id="line-filter"
+      aria-label="Línea"
+      value={filters.line}
+      onChange={(e) => onFilterChange('line', e.target.value)}
+      className={SELECT_CLASS}
+    >
+      <option value="">Todas las líneas</option>
+      {lineCollections.map((col) => (
+        <option key={col} value={col}>{COLLECTION_LABELS[col]}</option>
+      ))}
+    </select>
+  );
+
+  const brandSelect = (
+    <select
+      id="brand-filter"
+      aria-label="Marca"
+      value={filters.brand}
+      onChange={(e) => onFilterChange('brand', e.target.value)}
+      className={SELECT_CLASS}
+    >
+      <option value="">Todas las marcas</option>
+      {brands.map((brand) => <option key={brand} value={brand}>{brand}</option>)}
+    </select>
+  );
+
+  const genderSelect = (
+    <select
+      id="gender-filter"
+      aria-label="Género"
+      value={filters.gender}
+      onChange={(e) => onFilterChange('gender', e.target.value)}
+      className={SELECT_CLASS}
+    >
+      <option value="">Todos los géneros</option>
+      {genders.map((gender) => (
+        <option key={gender} value={gender}>{gender.charAt(0).toUpperCase() + gender.slice(1)}</option>
+      ))}
+    </select>
+  );
+
+  const categorySelect = (
+    <select
+      id="category-filter"
+      aria-label="Categoría"
+      value={filters.category}
+      onChange={(e) => onFilterChange('category', e.target.value)}
+      className={SELECT_CLASS}
+    >
+      <option value="">Todas las categorías</option>
+      {categories.map((category) => (
+        <option key={category} value={category}>{category.charAt(0).toUpperCase() + category.slice(1)}</option>
+      ))}
+    </select>
+  );
+
+  const sortSelect = (
+    <select
+      id="sort-filter"
+      aria-label="Ordenar por"
+      value={filters.sort}
+      onChange={(e) => onFilterChange('sort', e.target.value)}
+      className={SELECT_CLASS}
+    >
+      <option value="featured">Recomendados</option>
+      <option value="price-asc">Menor precio</option>
+      <option value="price-desc">Mayor precio</option>
+      <option value="name-asc">Nombre A-Z</option>
+      <option value="brand-asc">Marca A-Z</option>
+    </select>
+  );
+
+  const priceInputs = (
+    <div className="grid grid-cols-2 gap-2">
+      <input
+        type="number"
+        aria-label="Precio desde"
+        min={minCatalogPrice}
+        max={maxCatalogPrice}
+        value={filters.minPrice}
+        onChange={(e) => onFilterChange('minPrice', e.target.value)}
+        placeholder={`Desde ${minCatalogPrice}`}
+        className={`${SELECT_CLASS} text-sm`}
+      />
+      <input
+        type="number"
+        aria-label="Precio hasta"
+        min={minCatalogPrice}
+        max={maxCatalogPrice}
+        value={filters.maxPrice}
+        onChange={(e) => onFilterChange('maxPrice', e.target.value)}
+        placeholder={`Hasta ${maxCatalogPrice}`}
+        className={`${SELECT_CLASS} text-sm`}
+      />
+    </div>
+  );
+
+  const clearButton = (
+    <button
+      onClick={() => {
+        onResetFilters();
+        setIsOpen(false);
+      }}
+      className="flex w-full items-center justify-center rounded-md bg-[#1A2238] px-4 py-2 text-white transition-all duration-200 hover:bg-[#25304F]"
+    >
+      <X size={16} className="mr-2" />
+      Limpiar filtros
+    </button>
+  );
+
+  const activeChips = activeFilters.length > 0 && (
+    <div className="flex flex-wrap gap-2">
+      {activeFilters.map(filter => (
+        <span key={filter} className="rounded-full bg-[#F8F0E3] px-3 py-1 text-xs font-medium text-[#1A2238]">
+          {filter}
+        </span>
+      ))}
+    </div>
+  );
+
+  // ── Bar layout ─────────────────────────────────────────────────────────────
+  if (layout === "bar") {
+    return (
+      <div className="rounded-lg border border-[#E8DDBF] bg-white p-3 shadow-sm sm:p-4">
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className="flex w-full items-center justify-between text-[#1A2238] lg:hidden"
+          aria-expanded={isOpen}
+        >
+          <span className="flex items-center">
+            <Filter size={18} className="mr-2" />
+            Filtros
+            {activeFilters.length > 0 && (
+              <span className="ml-2 rounded-full bg-[#D4AF37] px-2 py-0.5 text-xs font-semibold text-white">
+                {activeFilters.length}
+              </span>
+            )}
+          </span>
+          <ChevronDown className={`transition-transform ${isOpen ? 'rotate-180' : ''}`} size={18} />
+        </button>
+
+        <div className={`${isOpen ? 'mt-3 block' : 'hidden'} lg:mt-0 lg:block`}>
+          {/* Seven columns so the price range — two inputs sharing a cell —
+              gets double the width of a single select and stops clipping. */}
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-7 lg:items-center">
+            {lineSelect}
+            {brandSelect}
+            {genderSelect}
+            {categorySelect}
+            {sortSelect}
+            <div className="sm:col-span-2 lg:col-span-2">{priceInputs}</div>
+          </div>
+
+          {(activeFilters.length > 0) && (
+            <div className="mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-[#E8DDBF] pt-3">
+              {activeChips}
+              <button
+                onClick={onResetFilters}
+                className="flex items-center gap-1 text-sm font-medium text-[#9A7A1F] hover:underline"
+              >
+                <X size={14} />
+                Limpiar
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Panel layout ───────────────────────────────────────────────────────────
   return (
     <div className="rounded-lg border border-[#E8DDBF] bg-white shadow-sm">
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="flex w-full items-center justify-between p-4 text-[#1A2238] lg:hidden"
+        aria-expanded={isOpen}
       >
         <span className="flex items-center">
           <Filter size={20} className="mr-2" />
@@ -58,7 +250,7 @@ const Filters: React.FC<FilterProps> = ({ filters, onFilterChange, onResetFilter
         </span>
         <ChevronDown className={`transition-transform ${isOpen ? 'rotate-180' : ''}`} size={20} />
       </button>
-      
+
       <div className={`${isOpen ? 'block' : 'hidden'} lg:block p-4`}>
         <div className="mb-4 hidden items-center justify-between lg:flex">
           <h2 className="flex items-center font-serif text-xl font-semibold text-[#1A2238]">
@@ -67,143 +259,42 @@ const Filters: React.FC<FilterProps> = ({ filters, onFilterChange, onResetFilter
           </h2>
         </div>
 
-        {activeFilters.length > 0 && (
-          <div className="mb-4 flex flex-wrap gap-2">
-            {activeFilters.map(filter => (
-              <span key={filter} className="rounded-full bg-[#F8F0E3] px-3 py-1 text-xs font-medium text-[#1A2238]">
-                {filter}
-              </span>
-            ))}
-          </div>
-        )}
-        
+        {activeFilters.length > 0 && <div className="mb-4">{activeChips}</div>}
+
         <div className="mb-4">
           <label htmlFor="line-filter" className="mb-2 block font-medium text-[#1A2238]">Línea</label>
-          <select
-            id="line-filter"
-            value={filters.line}
-            onChange={(e) => onFilterChange('line', e.target.value)}
-            className="w-full rounded border border-gray-300 p-2 focus:outline-none focus:ring-1 focus:ring-[#D4AF37]"
-          >
-            <option value="">Todas las líneas</option>
-            {lineCollections.map((col) => (
-              <option key={col} value={col}>
-                {COLLECTION_LABELS[col]}
-              </option>
-            ))}
-          </select>
+          {lineSelect}
         </div>
 
         <div className="mb-4">
           <label htmlFor="brand-filter" className="mb-2 block font-medium text-[#1A2238]">Marca</label>
-          <select
-            id="brand-filter"
-            value={filters.brand}
-            onChange={(e) => onFilterChange('brand', e.target.value)}
-            className="w-full rounded border border-gray-300 p-2 focus:outline-none focus:ring-1 focus:ring-[#D4AF37]"
-          >
-            <option value="">Todas las marcas</option>
-            {brands.map((brand) => (
-              <option key={brand} value={brand}>
-                {brand}
-              </option>
-            ))}
-          </select>
+          {brandSelect}
         </div>
 
         <div className="mb-4">
           <label htmlFor="gender-filter" className="mb-2 block font-medium text-[#1A2238]">Género</label>
-          <select
-            id="gender-filter"
-            value={filters.gender}
-            onChange={(e) => onFilterChange('gender', e.target.value)}
-            className="w-full rounded border border-gray-300 p-2 focus:outline-none focus:ring-1 focus:ring-[#D4AF37]"
-          >
-            <option value="">Todos los géneros</option>
-            {genders.map((gender) => (
-              <option key={gender} value={gender}>
-                {gender.charAt(0).toUpperCase() + gender.slice(1)}
-              </option>
-            ))}
-          </select>
+          {genderSelect}
         </div>
 
         <div className="mb-4">
           <label htmlFor="category-filter" className="mb-2 block font-medium text-[#1A2238]">Categoría</label>
-          <select
-            id="category-filter"
-            value={filters.category}
-            onChange={(e) => onFilterChange('category', e.target.value)}
-            className="w-full rounded border border-gray-300 p-2 focus:outline-none focus:ring-1 focus:ring-[#D4AF37]"
-          >
-            <option value="">Todas las categorías</option>
-            {categories.map((category) => (
-              <option key={category} value={category}>
-                {category.charAt(0).toUpperCase() + category.slice(1)}
-              </option>
-            ))}
-          </select>
+          {categorySelect}
         </div>
 
         <div className="mb-4">
           <label htmlFor="sort-filter" className="mb-2 block font-medium text-[#1A2238]">Ordenar por</label>
-          <select
-            id="sort-filter"
-            value={filters.sort}
-            onChange={(e) => onFilterChange('sort', e.target.value)}
-            className="w-full rounded border border-gray-300 p-2 focus:outline-none focus:ring-1 focus:ring-[#D4AF37]"
-          >
-            <option value="featured">Recomendados</option>
-            <option value="price-asc">Menor precio</option>
-            <option value="price-desc">Mayor precio</option>
-            <option value="name-asc">Nombre A-Z</option>
-            <option value="brand-asc">Marca A-Z</option>
-          </select>
+          {sortSelect}
         </div>
 
         <div className="mb-4 rounded-lg bg-[#FBF8F1] p-3">
           <div className="mb-3 text-sm font-medium text-[#1A2238]">Rango de precio</div>
-          <div className="grid grid-cols-2 gap-2">
-            <label className="text-xs text-gray-600">
-              Desde
-              <input
-                type="number"
-                min={minCatalogPrice}
-                max={maxCatalogPrice}
-                value={filters.minPrice}
-                onChange={(e) => onFilterChange('minPrice', e.target.value)}
-                placeholder={String(minCatalogPrice)}
-                className="mt-1 w-full rounded border border-gray-300 p-2 text-sm focus:outline-none focus:ring-1 focus:ring-[#D4AF37]"
-              />
-            </label>
-            <label className="text-xs text-gray-600">
-              Hasta
-              <input
-                type="number"
-                min={minCatalogPrice}
-                max={maxCatalogPrice}
-                value={filters.maxPrice}
-                onChange={(e) => onFilterChange('maxPrice', e.target.value)}
-                placeholder={String(maxCatalogPrice)}
-                className="mt-1 w-full rounded border border-gray-300 p-2 text-sm focus:outline-none focus:ring-1 focus:ring-[#D4AF37]"
-              />
-            </label>
-          </div>
+          {priceInputs}
           <div className="mt-2 text-xs text-gray-500">
             Catálogo: {formatPrice(minCatalogPrice)} - {formatPrice(maxCatalogPrice)}
           </div>
         </div>
 
-        <button
-          onClick={() => {
-            onResetFilters();
-            setIsOpen(false);
-          }}
-          className="flex w-full items-center justify-center rounded-md bg-[#1A2238] px-4 py-2 text-white transition-all duration-200 hover:bg-[#25304F]"
-        >
-          <X size={16} className="mr-2" />
-          Limpiar filtros
-        </button>
+        {clearButton}
       </div>
     </div>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,9 +8,11 @@ interface HeaderProps {
   toggleCart: () => void;
   /** Abre el AdminPanel (que tiene su propio gate con contraseña). Opcional. */
   onOpenAdmin?: () => void;
+  /** Vuelve el catálogo a su estado inicial. El logo es la salida de emergencia. */
+  onGoHome?: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ searchQuery, onSearch, toggleCart, onOpenAdmin }) => {
+const Header: React.FC<HeaderProps> = ({ searchQuery, onSearch, toggleCart, onOpenAdmin, onGoHome }) => {
   const { getCartCount } = useCart();
   const cartCount = getCartCount();
 
@@ -20,7 +22,20 @@ const Header: React.FC<HeaderProps> = ({ searchQuery, onSearch, toggleCart, onOp
         <div className="flex flex-col sm:flex-row items-center gap-4">
           <div className="flex items-center justify-between w-full sm:w-auto">
             <h1 className="whitespace-nowrap font-serif text-2xl font-bold text-[#1A2238] sm:text-3xl">
-              <span className="text-[#D4AF37]">DT</span>Fragancias
+              {onGoHome ? (
+                <button
+                  onClick={onGoHome}
+                  className="rounded transition-opacity hover:opacity-70 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#D4AF37]"
+                  title="Volver al inicio y limpiar la búsqueda"
+                  aria-label="DTFragancias — volver al inicio"
+                >
+                  <span className="text-[#D4AF37]">DT</span>Fragancias
+                </button>
+              ) : (
+                <>
+                  <span className="text-[#D4AF37]">DT</span>Fragancias
+                </>
+              )}
             </h1>
 
             <div className="sm:hidden flex items-center gap-1">

--- a/src/data/catalogQuery.ts
+++ b/src/data/catalogQuery.ts
@@ -11,9 +11,7 @@ import { Perfume } from "../types";
 export interface CatalogFilters {
   collection: string;
   line: string;
-  brand: string;
   gender: string;
-  category: string;
   minPrice: string;
   maxPrice: string;
   sort: string;
@@ -22,9 +20,7 @@ export interface CatalogFilters {
 export const EMPTY_FILTERS: CatalogFilters = {
   collection: "featured",
   line: "",
-  brand: "",
   gender: "",
-  category: "",
   minPrice: "",
   maxPrice: "",
   sort: "featured",
@@ -71,9 +67,7 @@ export function filterPerfumes(perfumes: Perfume[], filters: CatalogFilters, sea
   return perfumes.filter(perfume => {
     if (search && !matchesSearch(perfume, search)) return false;
     if (filters.line && perfume.collection !== filters.line) return false;
-    if (filters.brand && perfume.brand !== filters.brand) return false;
     if (filters.gender && perfume.gender !== filters.gender) return false;
-    if (filters.category && perfume.category !== filters.category) return false;
     if (!matchesCollectionChip(perfume, filters.collection)) return false;
     if (hasMin && !(typeof perfume.price === "number" && perfume.price >= minPrice)) return false;
     if (hasMax && !(typeof perfume.price === "number" && perfume.price <= maxPrice)) return false;


### PR DESCRIPTION
Los filtros pasan a una barra horizontal arriba de la grilla, y la elección entre barra y panel queda a mano, igual que la de grilla y lista.

## Por qué

El panel lateral se llevaba **un cuarto del ancho**. En una pantalla grande eso es una columna entera de productos que no ves.

Con los filtros arriba, la grilla pasa de 3 a 4 columnas en `xl`: **33% más perfumes por pantalla**, sin scrollear.

## Qué cambia

- `Filters` acepta `layout="bar" | "panel"`
- Los cinco selects y el rango de precio se declaran **una sola vez** y sólo cambia el contenedor, así que las dos variantes no se pueden desincronizar
- La barra arranca elegida y la preferencia se guarda en `localStorage`, igual que grilla/lista
- La grilla suma `xl:grid-cols-4` sólo cuando los filtros están arriba

## Mobile queda igual

El toggle Barra/Panel sólo aparece en `lg` y más arriba. Abajo de eso los filtros ya colapsaban en un botón "Filtros" y el panel lateral nunca se mostraba, así que ofrecer la elección no significaba nada.

Comparado contra `main` en 430px: idéntico.

## Sobre el enfoque

Es un cambio de **layout**, no un rediseño. Se respetan los tokens que ya existen — borde `#E8DDBF`, focus `#D4AF37`, navy `#1A2238` — porque el catálogo ya tiene una identidad y el pedido era ganar ancho, no cambiar de cara.

## Verificación

- `tsc --noEmit` y `eslint` sin errores
- 428 productos, 24 cards, sin errores de carga
- Grilla en 4 columnas confirmada en el DOM
- Revisado a 1600px y a 430px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Agregado después de la primera revisión

### Se sacaron los filtros de marca y categoría

**Marca** tenía cuatro valores para 428 productos, así que casi nunca acotaba nada. **Categoría** tenía veinticuatro familias olfativas — un desplegable que pedía saber de perfumería antes de poder usarlo.

Con línea, género, orden y rango de precio la barra queda legible y los selects dejan de apretarse. Se sacaron también del tipo `CatalogFilters` y de `filterPerfumes`: dejar estado sin ningún control que lo escriba es código que se pudre.

El subtítulo prometía filtrar por marca y perfil; ahora dice lo que hay.

### El logo vuelve al inicio

Era un `<h1>` sin comportamiento, y es lo primero que la gente toca cuando se perdió entre filtros. Ahora limpia filtros y búsqueda, cierra el detalle abierto y sube la página.

Sigue siendo el `h1` de la página — el botón va adentro para no perder la jerarquía del encabezado — y `onGoHome` es opcional, así que sin el prop se renderiza como antes.
