### PR TITLE
fix(catalog): incluir la variante elegida en la consulta de WhatsApp

### DIFF
--- a/src/components/PerfumeDetails.tsx
+++ b/src/components/PerfumeDetails.tsx
@@ -62,7 +62,7 @@ const PerfumeDetails: React.FC<PerfumeDetailsProps> = ({ perfume, onClose, onAdd
   };
 
   const handleWhatsappInquiry = () => {
-    window.open(buildWhatsappUrl(buildProductInquiryMessage(perfume)), "_blank");
+    window.open(buildWhatsappUrl(buildProductInquiryMessage(perfume, selectedVariant)), "_blank");
   };
 
   const handleCopyLink = async () => {

--- a/src/utils/whatsapp.ts
+++ b/src/utils/whatsapp.ts
@@ -1,6 +1,6 @@
 import { CartItem } from "../types";
 import { computeNumericTotal, formatPrice, lineItemTotal } from "./price";
-import { Perfume } from "../types";
+import { Perfume, PerfumeVariant } from "../types";
 
 export const WHATSAPP_PHONE_NUMBER = "541145630304";
 
@@ -27,7 +27,7 @@ export function buildWhatsappMessage(cart: CartItem[]): string {
   return `Hola DTFragancias, quiero hacer este pedido:\n\n${lines.join("\n")}\n\n*Total estimado: ${totalText}*\n\nMe confirmás disponibilidad, precio final, demora por pedido y forma de entrega? Gracias.`;
 }
 
-export function buildProductInquiryMessage(perfume: Perfume): string {
+export function buildProductInquiryMessage(perfume: Perfume, variant?: PerfumeVariant): string {
   const price = formatPrice(perfume.price);
   const notes = [
     perfume.occasion,
@@ -35,5 +35,9 @@ export function buildProductInquiryMessage(perfume: Perfume): string {
     perfume.intensity && `Intensidad ${perfume.intensity}`,
   ].filter(Boolean).join(" | ");
 
-  return `Hola DTFragancias, quiero consultar por este perfume:\n\n*${perfume.name}*\nMarca: ${perfume.brand}\nTamaño: ${perfume.size}\nPrecio: ${price}\nPerfil: ${perfume.category}\n${notes ? `Detalle: ${notes}\n` : ""}\nMe confirmás disponibilidad, precio final y demora por pedido?`;
+  // The chosen option rides with the name, same as the cart message: it is what
+  // has to be ordered, and burying it lower risks the wrong one being sent.
+  const variantSuffix = variant ? ` · ${variant.name}` : "";
+
+  return `Hola DTFragancias, quiero consultar por este perfume:\n\n*${perfume.name}${variantSuffix}*\nMarca: ${perfume.brand}\nTamaño: ${perfume.size}\nPrecio: ${price}\nPerfil: ${perfume.category}\n${notes ? `Detalle: ${notes}\n` : ""}\nMe confirmás disponibilidad, precio final y demora por pedido?`;
 }


### PR DESCRIPTION
## Qué

En el detalle de producto, el botón **"Consultar este perfume por WhatsApp"** no incluía la variante elegida en el mensaje. Si el cliente entraba a un producto Home (difusor, vela, jabón), elegía un aroma y consultaba, el mensaje salía sin decir cuál — obligando a repreguntarlo.

## Causa

`buildProductInquiryMessage` solo recibía el `perfume`, nunca la variante. El componente ya tenía `selectedVariant` en estado, pero no lo pasaba a la función.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `src/utils/whatsapp.ts` | `buildProductInquiryMessage(perfume, variant?)` acepta un `PerfumeVariant` opcional y lo agrega pegado al nombre, estilo carrito (`*Nombre · Variante*`) |
| `src/components/PerfumeDetails.tsx` | `handleWhatsappInquiry` ahora pasa `selectedVariant` |

## Prueba

- [x] `npm run build` sin errores
- [x] Probado en local (`VITE_USE_LOCAL_CATALOG=true`) sobre "Aromaterapia — Difusor 150ml": eligiendo "Happy" el mensaje sale `*Aromaterapia — Difusor 150ml · Happy*`
- [x] Sin variante elegida, el mensaje queda igual que antes (parámetro opcional, cambio aditivo)