### PR TITLE
fix(catalog): evitar agregar al carrito sin elegir variante desde la vista lista

### DIFF
--- a/src/components/PerfumeListItem.tsx
+++ b/src/components/PerfumeListItem.tsx
@@ -19,9 +19,20 @@ const PerfumeListItem: React.FC<PerfumeListItemProps> = ({ perfume, onShowDetail
   const isConsultPrice = typeof perfume.price !== "number";
   const favorite = isFavorite(perfume.id);
   const lineBadge = getLineBadge(perfume);
+  const variantCount = perfume.variants?.length ?? 0;
+  const hasVariants = variantCount > 0;
 
   const handleAddToCart = (e: React.MouseEvent) => {
     e.stopPropagation();
+
+    // A product sold in several scents cannot be quick-added from the list: the
+    // row has no way to say which one, and a cart line without it is an order you
+    // have to chase down over WhatsApp. Send the shopper to the detail to choose.
+    if (hasVariants) {
+      onShowDetails(perfume);
+      return;
+    }
+
     addToCart(perfume);
     if (onAddToCart) {
       onAddToCart(perfume);
@@ -82,11 +93,17 @@ const PerfumeListItem: React.FC<PerfumeListItemProps> = ({ perfume, onShowDetail
             </span>
           ) : null}
 
+          {hasVariants && (
+            <span className="rounded-full bg-[#D4AF37]/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#9A7A1F]">
+              {variantCount} opciones
+            </span>
+          )}
+
           <button
             onClick={handleAddToCart}
             className="ml-auto flex-shrink-0 rounded-full bg-[#1A2238] p-1.5 text-white transition-colors hover:bg-[#25304F]"
-            aria-label={`Agregar ${perfume.name} al carrito`}
-            title="Agregar al carrito"
+            aria-label={hasVariants ? `Elegir una opción de ${perfume.name}` : `Agregar ${perfume.name} al carrito`}
+            title={hasVariants ? "Elegir una opción" : "Agregar al carrito"}
           >
             <Plus size={16} />
           </button>


### PR DESCRIPTION
## Qué

En la **vista lista** del catálogo, el botón "+" agregaba cualquier producto al carrito sin chequear si tenía variantes. Para un producto multi-aroma (ej. un difusor Home en Happy/Energy/Calm), esto metía una línea al carrito **sin aroma elegido**, generando un pedido de WhatsApp ambiguo — el mismo problema que la vista grilla ya evita.

## Causa

`PerfumeCard.tsx` (grilla) tiene un guard: si el producto tiene variantes, el "+" abre el detalle para elegir en vez de agregar. `PerfumeListItem.tsx` (lista) no tenía ese guard.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `src/components/PerfumeListItem.tsx` | El "+" ahora abre el detalle cuando el producto tiene variantes (espejo del guard de `PerfumeCard`). Se agrega un badge "N opciones" y el botón cambia su etiqueta a "Elegir una opción". |

## Prueba

- [x] `npm run build` sin errores
- [x] Probado en local (`VITE_USE_LOCAL_CATALOG=true`), vista lista:
  - Producto con variantes ("Aromaterapia — Difusor 150ml", badge "4 opciones") → el "+" abre el detalle, el carrito queda vacío
  - Producto sin variantes ("Bad Girl 90ml") → el "+" agrega directo, carrito en 1 (sin regresión)